### PR TITLE
Add volatile keyword to Datasource singleton instance

### DIFF
--- a/src/main/java/com/programmingskillz/samplejerseywebapp/data/DataSource.java
+++ b/src/main/java/com/programmingskillz/samplejerseywebapp/data/DataSource.java
@@ -8,7 +8,7 @@ import com.zaxxer.hikari.HikariDataSource;
  */
 public class DataSource extends HikariDataSource {
 
-  private static DataSource instance;
+  private static volatile DataSource instance;
 
   private DataSource() {
     super(new HikariConfig("/hikari.properties"));


### PR DESCRIPTION
`The volatile keyword now ensures that multiple threads handle the singleton instance correctly`
https://en.wikipedia.org/wiki/Double-checked_locking#cite_ref-Boehm2005_5-0